### PR TITLE
Add browser path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.5",
   "description": "Strategy for using validatorjs with react-validation-mixin",
   "main": "./src/strategy.js",
+  "browser": "./dist/strategy.js",
   "dependencies": {
     "validatorjs": "2.0.5"
   },


### PR DESCRIPTION
For my build process I use Gulp/Browserify/Babelify and everything works fine in development. However, for production, I add UglifyJS to the mix and it chokes on `./src/strategy.js` (you can see for yourself [here](http://lisperator.net/uglifyjs/)).

Adding the `browser` path to package.json allows it to use the compiled version instead and everything works fine. Hope this works for you too.
