### PR TITLE
Bump validatorjs to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Strategy for using validatorjs with react-validation-mixin",
   "main": "./lib/strategy.js",
   "dependencies": {
-    "validatorjs": "2.0.5"
+    "validatorjs": "3.7.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
The version you are using is pretty old.
The current version is 3.7.0.
Hopefully no API is broken. I haven't checked.
